### PR TITLE
UPGRADE lodash to latest,

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "extract-text-webpack-plugin": "0.8.2",
     "findup": "0.1.5",
     "glob": "5.0.15",
-    "lodash": "3.10.1",
+    "lodash": "4.6.1",
     "marked": "0.3.5",
     "minimist": "1.2.0",
     "postcss-advanced-variables": "1.2.2",
@@ -54,7 +54,7 @@
     "webpack-merge": "0.2.0"
   },
   "peerDependencies": {
-    "react": ">=0.14.0",
+    "react": ">=0.14.2",
     "react-dom": "~0.14.2"
   },
   "devDependencies": {
@@ -70,7 +70,8 @@
     "mocha": "~2.3.3",
     "postcss-modules-extract-imports": "~1.0.0",
     "postcss-modules-scope": "~1.0.0",
-    "react": "~0.14.2"
+    "react": "~0.14.2",
+    "react-dom": "~0.14.2"
   },
   "scripts": {
     "test": "npm run lint && npm run mocha && npm run build",

--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -4,7 +4,7 @@ import 'codemirror/lib/codemirror.css';
 
 import _ from 'lodash';
 import { Component, PropTypes } from 'react';
-import debounce from 'lodash/function/debounce';
+import debounce from 'lodash/debounce';
 import Codemirror from 'react-codemirror';
 
 import s from './Editor.css';

--- a/test/utils.utils.spec.js
+++ b/test/utils.utils.spec.js
@@ -15,7 +15,7 @@ describe('utils', () => {
 					module: {name: 'Bar'}
 				}
 			]);
-			expect(_.pluck(result, 'name')).to.eql(['Foo', 'Bar']);
+			expect(_.map(result, 'name')).to.eql(['Foo', 'Bar']);
 		});
 	});
 


### PR DESCRIPTION
FIX problems arisen from the upgrade,
But eslint is not able to lint because of `TypeError: Cannot read property 'visitClass' of undefined`. Seems to be unrelated to the upgrade of lodash.
Mocha tests are passing

Should there be a dev branch to PR to?
